### PR TITLE
Changed Release workflow to update before installing utils

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -9,6 +9,9 @@ jobs:
     name: Cut a release
     runs-on: aws-athena-query-federation_ubuntu-latest_16-core 
     steps:
+      - name: Update
+        run: |
+          sudo apt-get update
       - name: Setup dependencies
         run: |
           sudo apt-get install -y libxml2-utils python3


### PR DESCRIPTION
*Issue #, if available:*
`libxml2-utils` wasn't able to install; running update before installing utils solved the issue. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
