### PR TITLE
Revert "Migrate cut release workflow to use AWS Ubuntu image (#283)"

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cut_release:
     name: Cut a release
-    runs-on: aws-athena-query-federation_ubuntu-latest_16-core 
+    runs-on: ubuntu-latest
     steps:
       - name: Update
         run: |


### PR DESCRIPTION
This reverts commit b4b8168b9d40333d025d9bf952dc7ae501e42b2d.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
